### PR TITLE
Modified TLS/SSL tester API to start with frida script

### DIFF
--- a/Mobile-Security-Framework-MobSF-3.7.6/mobsf/DynamicAnalyzer/views/android/tests_frida.py
+++ b/Mobile-Security-Framework-MobSF-3.7.6/mobsf/DynamicAnalyzer/views/android/tests_frida.py
@@ -140,6 +140,22 @@ def instrument(request, api=False):
     return send_response(data, api)
 
 
+def run_with_instrument(md5_hash, default_hooks, auxiliary_hooks):
+    extras = {}
+    package = get_package_name(md5_hash)
+    with open(settings.DEFAULT_SCRIPT, "r") as bypass_code:
+        code = bypass_code.read()
+    frida_obj = Frida(md5_hash,
+                        package,
+                        default_hooks,
+                        auxiliary_hooks,
+                        extras,
+                        code)
+    trd = threading.Thread(target=frida_obj.connect)
+    trd.daemon = True
+    trd.start()
+
+
 def live_api(request, api=False):
     try:
         if api:

--- a/Mobile-Security-Framework-MobSF-3.7.6/mobsf/DynamicAnalyzer/views/android/tests_tls.py
+++ b/Mobile-Security-Framework-MobSF-3.7.6/mobsf/DynamicAnalyzer/views/android/tests_tls.py
@@ -16,6 +16,9 @@ from mobsf.DynamicAnalyzer.tools.webproxy import (
     get_traffic,
     stop_httptools,
 )
+from mobsf.DynamicAnalyzer.views.android.tests_frida import (
+    run_with_instrument,
+)
 
 
 HTTPS = re.compile(r'(GET|POST|HEAD|PUT|DELETE|'
@@ -56,7 +59,7 @@ def run_tls_tests(request, md5_hash, env, package, test_pkg, duration):
     logger.info('Running TLS Misconfiguration Test')
     env.configure_proxy(test_pkg, request)
     env.install_mobsf_ca('remove')
-    env.run_app(package)
+    run_with_instrument(md5_hash, [], [])
     env.wait(duration)
     stop_httptools(get_http_tools_url(request))
     traffic = get_traffic(test_pkg)
@@ -69,7 +72,7 @@ def run_tls_tests(request, md5_hash, env, package, test_pkg, duration):
     env.adb_command(['am', 'force-stop', package], True)
     logger.info('Running TLS Pinning/Certificate Transparency Test')
     env.configure_proxy(test_pkg, request)
-    env.run_app(package)
+    run_with_instrument(md5_hash, [], [])
     env.wait(duration)
     stop_httptools(get_http_tools_url(request))
     traffic = get_traffic(test_pkg)
@@ -82,17 +85,7 @@ def run_tls_tests(request, md5_hash, env, package, test_pkg, duration):
     env.adb_command(['am', 'force-stop', package], True)
     logger.info('Running TLS Pinning/Certificate Transparency Bypass Test')
     env.configure_proxy(test_pkg, request)
-    frd = Frida(
-        md5_hash,
-        package,
-        ['ssl_pinning_bypass', 'debugger_check_bypass', 'root_bypass'],
-        None,
-        None,
-        None,
-    )
-    trd = threading.Thread(target=frd.connect)
-    trd.daemon = True
-    trd.start()
+    run_with_instrument(md5_hash, ['ssl_pinning_bypass', 'debugger_check_bypass', 'root_bypass'], [])
     env.wait(duration)
     stop_httptools(get_http_tools_url(request))
     traffic = get_traffic(test_pkg)

--- a/Mobile-Security-Framework-MobSF-3.7.6/mobsf/MobSF/settings.py
+++ b/Mobile-Security-Framework-MobSF-3.7.6/mobsf/MobSF/settings.py
@@ -398,6 +398,7 @@ else:
     ANALYZER_IDENTIFIER = os.getenv('MOBSF_ANALYZER_IDENTIFIER', '')
     FRIDA_TIMEOUT = int(os.getenv('MOBSF_FRIDA_TIMEOUT', '4'))
     ACTIVITY_TESTER_SLEEP = int(os.getenv('MOBSF_ACTIVITY_TESTER_SLEEP', '4'))
+    DEFAULT_SCRIPT = os.getenv('MOBSF_DEFAULT_SCRIPT', 'D:\\Goorm\\Project_2_3\\frida_script.js')
     # ==============================================
 
     # ================HTTPS PROXY ===============


### PR DESCRIPTION
- 문제 상황
    : TLS/SSL 테스트 시 앱 내 탐지 코드를 우회하기 위한 스크립트를 함께 실행하지 않아, 앱이 실행되자마자 종료되어 테스트를 제대로 수행할 수 없었다.
- 해결 방안
    : tls/ssl 테스트 API를 수정하여 앱 실행 시 우회 코드를 적용하여 앱을 실행하도록 하였다.

- 수정된 부분
    - `settings.py` 파일 내 `DEFAULT_SCRIPT` 속성 추가: 이 속성값 경로의 코드를 앱 실행 시 기본적으로 실행하도록 함
        - `%userprofile%/.MobSF/config.py` 파일에서도 새로 추가된 `DEFAULT_SCRIPT` 속성을 추가해야 함
    - `mobsf/DynamicAnalyzer/views/android/test_frida.py` 파일 내 `run_with_instrument` 함수 추가 
    - `mobsf/DynamicAnalyzer/views/android/test_tls.py` 파일 내 `run_tls_tests` 함수 수정