### PR TITLE
Add nested apk analysis

### DIFF
--- a/app.py
+++ b/app.py
@@ -234,20 +234,21 @@ class Main:
                     if file.endswith('.apk'):
                         file_path = os.path.join(root, file)
                         apk_files.append(file_path)
-                        return file_path
+            print("Confirmation complete")
         else:
             print("Directory does not exist")
         
         if apk_files:
             print(len(apk_files), "nested apks were found.")
+            return apk_files
         else:
             print("nested apk was not found.")
 
-        print("Deleting nested apk folder...")
-        try:
-            shutil.rmtree(zip_dir_path)
-        except OSError as e:
-            print(f'Error: {e.filename} - {e.strerror}')
+#        print("Deleting nested apk folder...")
+#        try:
+#            shutil.rmtree(zip_dir_path)
+#        except OSError as e:
+#            print(f'Error: {e.filename} - {e.strerror}')
         print("---------------------------------------------------------------")
     
     def static_analysis(self):
@@ -275,16 +276,26 @@ class Main:
             print("---current seting---")
             self.get_status(self)
 
-        nested_check_result=self.nested_check(selected_file_path)    
+        nested_check_result=self.nested_check(selected_file_path)
+        print("---------------------------------------------------------------")
 
         if nested_check_result:
-                mobsf_api = MobSF_API(self.server_ip, self.api_key, nested_check_result)
-                print("[Nested APK Static analysis start...]")
-                print("Proceed Automatically Static Reporting nested apk file")
-                mobsf_api.scan()
-                mobsf_api.json_resp()
-                mobsf_api.pdf()
-        print("---------------------------------------------------------------")
+                for index, apk in enumerate(nested_check_result):
+                    print(f'[{index+1}/{len(nested_check_result)}] - {apk}')
+                    mobsf_api = MobSF_API(self.server_ip, self.api_key, apk)
+                    print("[Nested APK Static analysis start...]")
+                    print("Proceed Automatically Static Reporting nested apk file")
+                    response_data = mobsf_api.upload()
+                    if response_data:
+                        mobsf_api.scan()
+                        mobsf_api.json_resp()
+                        mobsf_api.pdf()
+                    else:
+                        print("Server is not running. Please check the MobSF server settings and ensure it is running before trying again.")
+                        print("---current seting---")
+                        self.get_status(self)
+                        print('Selected nested apk: ', apk)
+                    print("---------------------------------------------------------------")
         
         apk_path = self.choose_file_path()
         decryptor = APKDecryptor(apk_path, self.encryption_method)

--- a/app.py
+++ b/app.py
@@ -240,6 +240,7 @@ class Main:
         
         if apk_files:
             print(len(apk_files), "nested apks were found.")
+            print("---------------------------------------------------------------")
             return apk_files
         else:
             print("nested apk was not found.")


### PR DESCRIPTION
- static analysis 부분에서 자동으로 중첩 apk를 분석하도록 해두었습니다.
- 이에 따라 check_nested 함수에서 생성된 폴더들('analysis' 파일 명의 압축 해제 폴더)을 삭제하는 기능은 주석 처리 해두었습니다.
- 위에서 폴더가 삭제되게 되면 중첩 apk 분석이 불가합니다.
- 만약에 static analysis 키워드를 통해서가 분석이 진행되는 것이 아니라 nested check 커맨드를 통해 add_nested_path()함수가 실행될 때, 분석이 진행되도록 한다면 위에서 폴더를 삭제한 채로 유지가 가능합니다.
- * 기존 static analysis 0번실행시 nested check 함수 경로 오류 남 -> 이후 오류 없음 << 이부분에 대해서는 파악하지 못했습니다. 테스트 시에는 잘 돌아가서 만약 다시 발생한다면 알려주시면 감사하겠습니다.
- 기존 코드가 수정되어 발생한 오류가 확인되어 다시 돌려놨습니다. 어떤 기능을 수행하기 위한 수정이었는지는 모르겠으나 참고바랍니다.
